### PR TITLE
Initialize neovim clipboard on startup

### DIFF
--- a/lua/deferred-clipboard.lua
+++ b/lua/deferred-clipboard.lua
@@ -20,18 +20,18 @@ local function schedule_disable_of_continuous_clipboard_sync_on_focus_change()
     })
 end
 
+local function copy_register(from, to)
+		vim.fn.setreg(
+				to,
+				vim.fn.getreginfo(from)
+		)
+end
+
 local function schedule_clipboard_sync_on_focus_change()
     local deferred_clipboard_sync_group = vim.api.nvim_create_augroup(
         'DeferredClipboardSync',
         { clear = true }
     )
-
-    local function copy_register(from, to)
-        vim.fn.setreg(
-            to,
-            vim.fn.getreginfo(from)
-        )
-    end
 
     vim.api.nvim_create_autocmd({
         'FocusLost',
@@ -55,6 +55,7 @@ end
 
 function M.setup()
     schedule_clipboard_sync_on_focus_change()
+		copy_register('+', '"')
 
     if is_continuous_clipboard_sync_enabled() then
         schedule_disable_of_continuous_clipboard_sync_on_focus_change()

--- a/lua/deferred-clipboard.lua
+++ b/lua/deferred-clipboard.lua
@@ -21,10 +21,10 @@ local function schedule_disable_of_continuous_clipboard_sync_on_focus_change()
 end
 
 local function copy_register(from, to)
-		vim.fn.setreg(
-				to,
-				vim.fn.getreginfo(from)
-		)
+    vim.fn.setreg(
+        to,
+        vim.fn.getreginfo(from)
+    )
 end
 
 local function schedule_clipboard_sync_on_focus_change()
@@ -55,7 +55,7 @@ end
 
 function M.setup()
     schedule_clipboard_sync_on_focus_change()
-		copy_register('+', '"')
+    copy_register('+', '"')
 
     if is_continuous_clipboard_sync_enabled() then
         schedule_disable_of_continuous_clipboard_sync_on_focus_change()

--- a/lua/deferred-clipboard.lua
+++ b/lua/deferred-clipboard.lua
@@ -23,7 +23,7 @@ end
 local function copy_register(from, to)
     vim.fn.setreg(
         to,
-        vim.fn.getreginfo(from)
+        vim.fn.getreg(from)
     )
 end
 


### PR DESCRIPTION
Hi!

I noticed a small issue: the internal neovim register `"` is not initialized on startup, making a focus switch necessary to make sure it's properly set. This pull request should fix that.

Loved the project's approach. Let me know if this is not appropriate, or if changes are needed :)